### PR TITLE
Improve Pool's graceful shutdown

### DIFF
--- a/sync-engine/src/block_height_ranges.rs
+++ b/sync-engine/src/block_height_ranges.rs
@@ -12,21 +12,24 @@ impl BlockHeightRanges {
             chunk_size,
         }
     }
+    pub fn has_next(&self) -> bool {
+        self.next_range.start < self.next_range.end
+    }
 }
 
 impl Iterator for BlockHeightRanges {
     type Item = Range<u32>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.next_range.start >= self.next_range.end {
-            None
-        } else {
+        if self.has_next() {
             let next_start = self.next_range.start;
             let next_end = next_start + self.chunk_size;
 
             self.next_range.start = next_end;
 
             Some(next_start..next_end)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Previously, there was an indirection of making the master report to itself and used a delay in a bid to optimistically allow workers shutdown with no acknowlegments.

This change ensures that each worker has sent a finished shutting down acknowledgement to master before
breaking out of the event loop, allowing the pool to shutdown gracefully.